### PR TITLE
Migrate to tpm style of plugin

### DIFF
--- a/scripts/git_branch.sh
+++ b/scripts/git_branch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/helpers.sh"
+
+find_git_branch() {
+    head=$(< "$1/.git/HEAD")
+    if [[ $head == ref:\ refs/heads/* ]]; then
+        GIT_BRANCH=${head#*/*/}
+    elif [[ $head != '' ]]; then
+        GIT_BRANCH='(detached)'
+    else
+        GIT_BRANCH='(unknown)'
+    fi
+}
+
+main() {
+    find_git_repo "$1"
+    find_git_branch "$GIT_REPO"
+    echo "$GIT_BRANCH"
+}
+main $1

--- a/scripts/git_dirty.sh
+++ b/scripts/git_dirty.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/helpers.sh"
+
+find_git_dirty() {
+   local status=$(git --git-dir="$1/.git" status --porcelain 2> /dev/null)
+   if [[ "$status" != "" ]]; then
+     GIT_DIRTY='*'
+   else
+     GIT_DIRTY=''
+   fi
+}
+
+main() {
+    find_git_repo "$1"
+    find_git_dirty "$GIT_REPO"
+    echo "$GIT_DIRTY"
+}
+
+main $1

--- a/scripts/git_repo.sh
+++ b/scripts/git_repo.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/helpers.sh"
+
+main() {
+    find_git_repo "$1"
+    echo `basename $GIT_REPO`
+}
+main $1

--- a/scripts/git_stash.sh
+++ b/scripts/git_stash.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$CURRENT_DIR/helpers.sh"
+
+find_git_stash() {
+    if [ -e "$1/.git/refs/stash" ]; then
+        GIT_STASH='stash'
+    else
+        GIT_STASH='no-stash'
+    fi
+}
+
+main() {
+    find_git_repo "$1"
+    find_git_stash "$GIT_REPO"
+    echo "$GIT_STASH"
+}
+main $1

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,15 @@
+# Linux
+READLINK='readlink -e'
+find_git_repo() {
+    local dir="$1"
+    until [ "$dir" -ef / ]; do
+        echo "$dir"  > ~/debug
+        if [ -f "$dir/.git/HEAD" ]; then
+            GIT_REPO=`$READLINK $dir`/
+            return
+        fi
+        dir="$dir/.."
+    done
+    GIT_REPO=''
+    return
+}

--- a/tmux-git.tmux
+++ b/tmux-git.tmux
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+git_branch="#($CURRENT_DIR/scripts/git_branch.sh #{pane_current_path})"
+git_branch_interpolation="\#{git_branch}"
+git_repo="#($CURRENT_DIR/scripts/git_repo.sh #{pane_current_path})"
+git_repo_interpolation="\#{git_repo}"
+git_dirty="#($CURRENT_DIR/scripts/git_dirty.sh #{pane_current_path})"
+git_dirty_interpolation="\#{git_dirty}"
+git_stash="#($CURRENT_DIR/scripts/git_stash.sh #{pane_current_path})"
+git_stash_interpolation="\#{git_stash}"
+
+get_tmux_option() {
+    local option="$1"
+    local default_value="$2"
+    local option_value="$(tmux show-option -gqv "$option")"
+    if [ -z "$option_value" ]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
+}
+
+set_tmux_option() {
+    local option="$1"
+    local value="$2"
+    tmux set-option -gq "$option" "$value"
+}
+
+do_interpolation() {
+    local string="$1"
+    local git_branch_interpolated="${string/$git_branch_interpolation/$git_branch}"
+    local git_repo_interpolated="${git_branch_interpolated/$git_repo_interpolation/$git_repo}"
+    local git_dirty_interpolated="${git_repo_interpolated/$git_dirty_interpolation/$git_dirty}"
+    local git_all_interpolated="${git_dirty_interpolated/$git_stash_interpolation/$git_stash}"
+    echo "$git_all_interpolated"
+}
+
+update_tmux_option() {
+    local option="$1"
+    local option_value="$(get_tmux_option "$option")"
+    local new_option_value="$(do_interpolation "$option_value")"
+    set_tmux_option "$option" "$new_option_value "
+}
+
+main() {
+    update_tmux_option "status-right"
+    update_tmux_option "status-left"
+}
+main


### PR DESCRIPTION
Hi,

I used this script a lot. Recently I found [tpm](https://github.com/tmux-plugins/tpm), so I decided to migrate the script to a tpm plugin.

You can use it very easily now like this in your `tmux.conf`:

```
set -g status-right "#[fg=white]#{git_repo} | #{git_branch} | #{git_stash}[#{git_dirty}]"
```

There are some issues to be fixed but I would like to hear your thoughts about it first.  