### PR TITLE
status-left/right fixes for tmux 2.9

### DIFF
--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -5,6 +5,16 @@
 # from many github users. Thank you all.
 
 CONFIG_FILE=~/.tmux-git.conf
+TMUX_VER=$(tmux -V | cut -d ' ' -f2 | tr -d . )
+
+if [ $TMUX_VER -ge 29 ]; then
+	# If tmux version is 2.9 or greater, use status-left-style and
+	# status-right-style instead of status-left-attr and
+	# status-right-attr
+	TMUX_ATTR="-style"
+else
+	TMUX_ATTR="-attr"
+fi
 
 # Use a different readlink according the OS.
 # Kudos to https://github.com/npauzenga for the PR
@@ -118,9 +128,9 @@ update_tmux() {
         TMUX_STATUS_DEFINITION
         
         if [ "$GIT_DIRTY" ]; then 
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr bright > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR bright > /dev/null
         else
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
         fi
         
         tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_STATUS" > /dev/null            
@@ -134,7 +144,7 @@ update_tmux() {
         else
             # Be sure to unset GIT_DIRTY's bright when leaving a repository.
             # Kudos to https://github.com/danarnold for the idea
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
 
             # Set the out-repo status
             tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_OUTREPO_STATUS" > /dev/null


### PR DESCRIPTION
tmux version 2.9 renamed `status-right-attr` and `status-left-attr` to `status-right` and `status-left`. The changes I've written will check for the tmux version in `$PATH` using `tmux -V`, and will make use of `status-right` and `status-left` throughout tmux-git.sh if the version is greater or equal than 2.9. For tmux versions before version 2.9, `status-right-attr` and `status-left-attr` will be used in tmux-git.sh.