### PR TITLE
Replace -attr w/ -style for status-left/right if tmux >= v 2.9

### DIFF
--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -5,6 +5,16 @@
 # from many github users. Thank you all.
 
 CONFIG_FILE=~/.tmux-git.conf
+TMUX_VER=$(tmux -V | cut -d ' ' -f2 | tr -d . )
+
+if [ $TMUX_VER -ge 29 ]; then
+	# If tmux version is 2.9 or greater, use status-left-style and
+	# status-right-style instead of status-left-attr and
+	# status-right-attr
+	TMUX_ATTR="-style"
+else
+	TMUX_ATTR="-attr"
+fi
 
 # Use a different readlink according the OS.
 # Kudos to https://github.com/npauzenga for the PR
@@ -118,9 +128,9 @@ update_tmux() {
         TMUX_STATUS_DEFINITION
         
         if [ "$GIT_DIRTY" ]; then 
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr bright > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR bright > /dev/null
         else
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
         fi
         
         tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_STATUS" > /dev/null            
@@ -134,7 +144,7 @@ update_tmux() {
         else
             # Be sure to unset GIT_DIRTY's bright when leaving a repository.
             # Kudos to https://github.com/danarnold for the idea
-            tmux set-window-option status-$TMUX_STATUS_LOCATION-attr none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
 
             # Set the out-repo status
             tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_OUTREPO_STATUS" > /dev/null


### PR DESCRIPTION
Hi @drmad,

Thanks for pointing that out about the tmux changes. Bit silly of me to think my prior version fixed the issue without looking over the tmux changelog. And thanks for making a nice tool with tmux-git.  :smiley: 

I've altered my commit. Now, my code will use '-style' instead of '-attr' if tmux's version is 2.9 or greater. I think that should grant the proper behavior rather than (for example) first setting tmux's status-* as the literal text 'bright', as you pointed out my older version would do.

I also renamed my `ATTR` variable to `TMUX_ATTR` to make shell variable name collisions less likely.

Thanks again for your suggestions and speedy response.