### PR TITLE
tmux v 2.9a fix

### DIFF
--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -5,7 +5,7 @@
 # from many github users. Thank you all.
 
 CONFIG_FILE=~/.tmux-git.conf
-TMUX_VER=$(tmux -V | cut -d ' ' -f2 | tr -d . )
+TMUX_VER=$(tmux -V | sed 's/[^0-9]*//g' )
 
 if [ $TMUX_VER -ge 29 ]; then
 	# If tmux version is 2.9 or greater, use status-left-style and


### PR DESCRIPTION
Hi again @drmad,

For the latest version of tmux, version 2.9a, my previous solution to get tmux's version to test whether it is version 2.9 or greater fails, due to the addition of the alphabetic character `a` output by `tmux -V`. This proposed PR fixes this by using `sed` to strip out all non-numeric characters from `tmux -V`. So, `tmux 2.8` from `tmux -V` becomes 28, `tmux 2.9` becomes 29, `tmux 2.9a` becomes 29, etc.

Looking through tmux's past versions at https://github.com/tmux/tmux/releases, it seems that tmux is always versioned in the format `x.y`, with an occassional `a` character at the end to denote small changes not worthy of a bump in the major or minor number. The minor version has always been an integer between 0 and 9. (If this were not so, a version like 1.10 would yield 110, giving an erroneous result for the `if [ $TMUX_VER -ge 29 ]` test I wrote.)

So, my `sed` command should produce the proper output for all those versions. However, I have not confirmed if `tmux -V` always outputs the version number listed on tmux's Github releases page. I could test this PR with older versions of tmux if you want me to ensure this solution is robust for past versions of tmux, at least going back to a reasonably old version from a few years ago or so.