### PR TITLE
Use -style and remove version check

### DIFF
--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -5,16 +5,6 @@
 # from many github users. Thank you all.
 
 CONFIG_FILE=~/.tmux-git.conf
-TMUX_VER=$(tmux -V | sed 's/[^0-9]*//g' )
-
-if [ $TMUX_VER -ge 29 ]; then
-	# If tmux version is 2.9 or greater, use status-left-style and
-	# status-right-style instead of status-left-attr and
-	# status-right-attr
-	TMUX_ATTR="-style"
-else
-	TMUX_ATTR="-attr"
-fi
 
 # Use a different readlink according the OS.
 # Kudos to https://github.com/npauzenga for the PR
@@ -128,9 +118,9 @@ update_tmux() {
         TMUX_STATUS_DEFINITION
         
         if [ "$GIT_DIRTY" ]; then 
-            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR bright > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION-style bright > /dev/null
         else
-            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION-style none > /dev/null
         fi
         
         tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_STATUS" > /dev/null            
@@ -144,7 +134,7 @@ update_tmux() {
         else
             # Be sure to unset GIT_DIRTY's bright when leaving a repository.
             # Kudos to https://github.com/danarnold for the idea
-            tmux set-window-option status-$TMUX_STATUS_LOCATION$TMUX_ATTR none > /dev/null
+            tmux set-window-option status-$TMUX_STATUS_LOCATION-style none > /dev/null
 
             # Set the out-repo status
             tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_OUTREPO_STATUS" > /dev/null

--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -5,7 +5,7 @@
 # from many github users. Thank you all.
 
 CONFIG_FILE=~/.tmux-git.conf
-TMUX_VER=$(tmux -V | cut -d ' ' -f2 | tr -d . )
+TMUX_VER=$(tmux -V | sed 's/[^0-9]*//g' )
 
 if [ $TMUX_VER -ge 29 ]; then
 	# If tmux version is 2.9 or greater, use status-left-style and


### PR DESCRIPTION
Sounds good @drmad. I agree, I think we should just get rid of the `tmux -V` check altogether and replace `-attr` with `-style`. Almost everyone is probably on tmux v. 1.8 or newer. Debian old stable, for example, has 1.9 in its repos.  I'll close the other PR and if this PR seems fine to you we can go ahead with this simpler fix for the change introduced in tmux 2.9. :)