### PR TITLE
Add zsh support

### DIFF
--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -8,12 +8,10 @@ CONFIG_FILE=~/.tmux-git.conf
 
 # Use a different readlink according the OS.
 # Kudos to https://github.com/npauzenga for the PR
-if [[ `uname` == 'Darwin' ]]; then
-    # Mac
-    READLINK='greadlink -e'
-else
-    # Linux
-    READLINK='readlink -e'
+if [[ `uname` == 'Darwin' ]]; then # Mac
+    READLINK='greadlink'
+else # Linux
+    READLINK='readlink'
 fi
 
 # Check for a configuration file.
@@ -59,7 +57,7 @@ find_git_repo() {
     local dir=.
     until [ "$dir" -ef / ]; do
         if [ -f "$dir/.git/HEAD" ]; then
-            GIT_REPO=`$READLINK $dir`/
+            GIT_REPO=`$READLINK -e $dir`/
             return
         fi
         dir="../$dir"
@@ -81,8 +79,7 @@ find_git_branch() {
 
 # Taken from https://github.com/jimeh/git-aware-prompt
 find_git_dirty() {
-  local status=$(git status --porcelain 2> /dev/null)
-  if [[ "$status" != "" ]]; then
+  if [[ "$(git status --porcelain 2> /dev/null)" != "" ]]; then
     GIT_DIRTY='*'
   else
     GIT_DIRTY=''
@@ -101,7 +98,7 @@ update_tmux() {
 
     # The trailing slash is for avoiding conflicts with repos with 
     # similar names. Kudos to https://github.com/tillt for the bug report
-    CWD=`$READLINK "$(pwd)"`/
+    CWD=`$READLINK -e "$(pwd)"`/
 
     LASTREPO_LEN=${#TMUX_GIT_LASTREPO}
 
@@ -143,5 +140,15 @@ update_tmux() {
 
 }
 
+
 # Update the prompt for execute the script
-PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
+case $SHELL in
+    *bash)
+        PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
+        ;;
+    *zsh)
+        if ! (($precmd_functions[(Ie)update_tmux])); then
+            precmd_functions=($precmd_functions update_tmux)
+        fi
+        ;;
+esac

--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -143,12 +143,12 @@ update_tmux() {
 
 # Update the prompt for execute the script
 case $SHELL in
-    *bash)
-        PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
-        ;;
     *zsh)
         if ! (($precmd_functions[(Ie)update_tmux])); then
             precmd_functions=($precmd_functions update_tmux)
         fi
+        ;;
+    *)
+        PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
         ;;
 esac


### PR DESCRIPTION
This commit modifies tmux-git to support zsh.
Prior to this commit, there were three reasons that it failed on zsh:

1. in bash vs. zsh, unquoted string vars containing spaces
   are handled differently.

   In bash, unquoted string vars are automatically split upon expansion:

       READLINK='greadlink -e'
       GIT_REPO=`$READLINK $dir` # evaluates to GIT_REPO=`greadlink -e $dir`

   whereas in zsh, they are preserved as a whole string,
   leading to the following failure:

       READLINK='greadlink -e'
       GIT_REPO=`$READLINK $dir` # evaluates to GIT_REPO=`"greadlink -e" $dir`
       zsh: command not found: greadlink -e

   This commit extracts the `-e` flag out of the `$READLINK` variable.

   See https://unix.stackexchange.com/questions/528502 for more details.

2. in zsh, `$status` is a special variable
   that stores the exit code of the most recent command (like `$?`).

   This commit removes the `$status` variable altogether,
   since it is only referenced in one place.

3. zsh does not recognize the `PROMPT_COMMAND` variable.
   Instead we append to the `$precmd_functions` array.

   See https://superuser.com/questions/735660 for more details.