### PR TITLE
Add update_tmux to PROMPT_COMMAND only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@ Git branch in Tmux
 ==================
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/drmad/tmux-git)
 
-`tmux-git` shows information about the `git` repo of the current directory in 
+`tmux-git` shows information about the `git` repo of the current directory in
 `tmux` status bar, like current branch, *dirtiness*, stash, etc.
 
 ## Overview
 
 There are many solutions to integrate the current Git branch on your Linux terminal
 prompt (like [this one][1] and [this one][2], from where I borrowed most parts of
-this script), but I don't like to bloat my prompt. 
+this script), but I don't like to bloat my prompt.
 
 So I was thinking where can I put that information, and then I remembered the
-fabulous [Tmux][3]. `tmux` is a powerful and really cool client-server terminal 
-multiplexer, but it also provides a nice status bar. 
+fabulous [Tmux][3]. `tmux` is a powerful and really cool client-server terminal
+multiplexer, but it also provides a nice status bar.
 
-This script scans the current `bash` directory for a `git` repo. If it's found, 
+This script scans the current `bash` directory for a `git` repo. If it's found,
 then puts information about it in the status bar, like:
 
 * Project name (actually, is the `git` repo directory name)
-* Active branch 
-* 'Dirty' status (i.e., there are pending modifications to be committed) 
+* Active branch
+* 'Dirty' status (i.e., there are pending modifications to be committed)
 * Stashed changes
 
 ## Installation
@@ -29,8 +29,8 @@ Clone this project in your home directory, renaming the folder with a preceding
 dot for hiding it:
 
     git clone git://github.com/drmad/tmux-git.git ~/.tmux-git
-  
-Then, execute this line in a shell to add the script in the Bash initialization 
+
+Then, execute this line in a shell to add the script in the Bash initialization
 file (usually `.bashrc`, replace if needed):
 
     echo "if [[ \$TMUX ]]; then source ~/.tmux-git/tmux-git.sh; fi" >> ~/.bashrc
@@ -41,7 +41,7 @@ Run `tmux`, `cd` to a Git repo, and enjoy :)
 
     brew install coreutils
 
-## Configurarion
+## Configuration
 
 The configuration is stored in the file `~/.tmux-git.conf`, created at the first
 run of the script with default values. Just edit it, and reload `tmux`.
@@ -49,12 +49,12 @@ run of the script with default values. Just edit it, and reload `tmux`.
 ### Variables and functions
 
 * `TMUX_STATUS_LOCATION`: Position of the status on Tmux bar: `left` or `right`
-* `TMUX_OUTREPO_STATUS`: Tmux status for when you're out of a repo. Set by 
-  default to your pre-existing status line. 
+* `TMUX_OUTREPO_STATUS`: Tmux status for when you're out of a repo. Set by
+  default to your pre-existing status line.
 * `TMUX_STATUS_DEFINITION()`: This function sets the `TMUX_STATUS` variable, which
   is shown in the `tmux` bar. You can use any variable used across the script for
   creating this variable.
-  
+
 ## En español
 
 He realizado un post en español de las instrucciones de instalación en mi blog:

--- a/tmux-git.sh
+++ b/tmux-git.sh
@@ -25,22 +25,22 @@ if [ ! -f $CONFIG_FILE ]; then
 # Location of the status on tmux bar: left or right
 TMUX_STATUS_LOCATION='right'
 
-# Status for where you are out of a repo. Default is your pre-existing status 
-# line. 
+# Status for where you are out of a repo. Default is your pre-existing status
+# line.
 # Kudos to https://github.com/danarnold for the idea.
 TMUX_OUTREPO_STATUS=`tmux show -vg status-$TMUX_STATUS_LOCATION`
 
-# Function to build the status line. You need to define the $TMUX_STATUS 
+# Function to build the status line. You need to define the $TMUX_STATUS
 # variable.
 TMUX_STATUS_DEFINITION() {
-    # You can use any tmux status variables, and $GIT_BRANCH, $GIT_DIRTY, 
+    # You can use any tmux status variables, and $GIT_BRANCH, $GIT_DIRTY,
     # $GIT_FLAGS ( which is an array of flags ), and pretty much any variable
     # used in this script :-)
-    
+
     GIT_BRANCH="`basename "$GIT_REPO"` | branch: $GIT_BRANCH"
-    
+
     TMUX_STATUS="$GIT_BRANCH$GIT_DIRTY"
-    
+
     if [ ${#GIT_FLAGS[@]} -gt 0 ]; then
         TMUX_STATUS="$TMUX_STATUS [`IFS=,; echo "${GIT_FLAGS[*]}"`]"
     fi
@@ -96,7 +96,7 @@ find_git_stash() {
 
 update_tmux() {
 
-    # The trailing slash is for avoiding conflicts with repos with 
+    # The trailing slash is for avoiding conflicts with repos with
     # similar names. Kudos to https://github.com/tillt for the bug report
     CWD=`$READLINK -e "$(pwd)"`/
 
@@ -111,20 +111,20 @@ update_tmux() {
         find_git_dirty
 
         GIT_FLAGS=($GIT_STASH)
-        
+
         TMUX_STATUS_DEFINITION
-        
-        if [ "$GIT_DIRTY" ]; then 
+
+        if [ "$GIT_DIRTY" ]; then
             tmux set-window-option status-$TMUX_STATUS_LOCATION-style bright > /dev/null
         else
             tmux set-window-option status-$TMUX_STATUS_LOCATION-style none > /dev/null
         fi
-        
-        tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_STATUS" > /dev/null            
+
+        tmux set-window-option status-$TMUX_STATUS_LOCATION "$TMUX_STATUS" > /dev/null
 
     else
         find_git_repo
-        
+
         if [[ $GIT_REPO ]]; then
             export TMUX_GIT_LASTREPO="$GIT_REPO"
             update_tmux
@@ -149,6 +149,8 @@ case $SHELL in
         fi
         ;;
     *)
-        PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
+        if [[ $PROMPT_COMMAND != *update_tmux* ]]; then
+            PROMPT_COMMAND="update_tmux; $PROMPT_COMMAND"
+        fi
         ;;
 esac


### PR DESCRIPTION
I noticed a couple of `update_tmux` had accumulated in my `PROMPT_COMMAND`. I don't know how exactly this happened, but this PR should fix it.

Also fix a typo in **README.md**.

Just noticed that my editor trimmed some trailing whitespace. Let me know if I should undo this.